### PR TITLE
Modify and add new combination button.

### DIFF
--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -2028,6 +2028,8 @@ static bool retro_load_game_common()
 		}
 
 		bIsNeogeoCartGame = ((BurnDrvGetHardwareCode() & HARDWARE_PUBLIC_MASK) == HARDWARE_SNK_NEOGEO);
+		bIsPgmCartGame = ((BurnDrvGetHardwareCode() & HARDWARE_PUBLIC_MASK) == HARDWARE_IGS_PGM);
+		bIsCps1CartGame = ((BurnDrvGetHardwareCode() & HARDWARE_PUBLIC_MASK) == HARDWARE_CAPCOM_CPS1 || (BurnDrvGetHardwareCode() & HARDWARE_PUBLIC_MASK) == HARDWARE_CAPCOM_CPS1_QSOUND);
 
 		// Define nMaxPlayers early;
 		nMaxPlayers = BurnDrvGetMaxPlayers();

--- a/src/burner/libretro/retro_common.cpp
+++ b/src/burner/libretro/retro_common.cpp
@@ -43,6 +43,8 @@ struct GameInp *pgi_diag;
 struct GameInp *pgi_debug_dip_1;
 struct GameInp *pgi_debug_dip_2;
 bool bIsNeogeoCartGame                = false;
+bool bIsPgmCartGame                   = false;
+bool bIsCps1CartGame                  = false;
 bool allow_neogeo_mode                = true;
 bool neogeo_use_specific_default_bios = false;
 bool bAllowDepth32                    = false;

--- a/src/burner/libretro/retro_common.h
+++ b/src/burner/libretro/retro_common.h
@@ -236,6 +236,8 @@ extern struct GameInp *pgi_diag;
 extern struct GameInp *pgi_debug_dip_1;
 extern struct GameInp *pgi_debug_dip_2;
 extern bool bIsNeogeoCartGame;
+extern bool bIsPgmCartGame;
+extern bool bIsCps1CartGame;
 extern bool allow_neogeo_mode;
 extern bool core_aspect_par;
 extern bool bAllowDepth32;

--- a/src/burner/libretro/retro_input.cpp
+++ b/src/burner/libretro/retro_input.cpp
@@ -106,6 +106,8 @@ static void AnalyzeGameLayout()
 	INT32 nKickx3[MAX_PLAYERS] = {0, };
 	INT32 nKickInputs[MAX_PLAYERS][3];
 	INT32 nNeogeoButtons[MAX_PLAYERS][4];
+	INT32 nPgmButtons[MAX_PLAYERS][4];
+	INT32 nCps1Buttons[MAX_PLAYERS][2];
 
 	bStreetFighterLayout = false;
 	nMahjongKeyboards = 0;
@@ -187,6 +189,28 @@ static void AnalyzeGameLayout()
 				}
 				if (_stricmp(" Button D", bii.szName + 2) == 0) {
 					nNeogeoButtons[nPlayer][3] = i;
+				}
+			}
+			if (bIsPgmCartGame) {
+				if (_stricmp(" fire 1", bii.szInfo + 2) == 0) {
+					nPgmButtons[nPlayer][0] = i;
+				}
+				if (_stricmp(" fire 2", bii.szInfo + 2) == 0) {
+					nPgmButtons[nPlayer][1] = i;
+				}
+				if (_stricmp(" fire 3", bii.szInfo + 2) == 0) {
+					nPgmButtons[nPlayer][2] = i;
+				}
+				if (_stricmp(" fire 4", bii.szInfo + 2) == 0) {
+					nPgmButtons[nPlayer][3] = i;
+				}
+			}
+			if (bIsCps1CartGame) {
+				if (_stricmp(" fire 1", bii.szInfo + 2) == 0) {
+					nCps1Buttons[nPlayer][0] = i;
+				}
+				if (_stricmp(" fire 2", bii.szInfo + 2) == 0) {
+					nCps1Buttons[nPlayer][1] = i;
 				}
 			}
 		}
@@ -271,16 +295,83 @@ static void AnalyzeGameLayout()
 			pgi->nInput = GIT_MACRO_AUTO;
 			pgi->nType = BIT_DIGITAL;
 			pgi->Macro.nMode = 0;
-			sprintf(pgi->Macro.szName, "P%i Buttons BCD", nPlayer + 1);
+			sprintf(pgi->Macro.szName, "P%i Buttons BC", nPlayer + 1);
 			BurnDrvGetInputInfo(&bii, nNeogeoButtons[nPlayer][1]);
 			pgi->Macro.pVal[0] = bii.pVal;
 			pgi->Macro.nVal[0] = 1;
 			BurnDrvGetInputInfo(&bii, nNeogeoButtons[nPlayer][2]);
 			pgi->Macro.pVal[1] = bii.pVal;
 			pgi->Macro.nVal[1] = 1;
-			BurnDrvGetInputInfo(&bii, nNeogeoButtons[nPlayer][3]);
+			nMacroCount++;
+			pgi++;
+		}
+		if (bIsPgmCartGame) {
+			pgi->nInput = GIT_MACRO_AUTO;
+			pgi->nType = BIT_DIGITAL;
+			pgi->Macro.nMode = 0;
+			sprintf(pgi->Macro.szName, "P%i Buttons AB", nPlayer + 1);
+			BurnDrvGetInputInfo(&bii, nPgmButtons[nPlayer][0]);
+			pgi->Macro.pVal[0] = bii.pVal;
+			pgi->Macro.nVal[0] = 1;
+			BurnDrvGetInputInfo(&bii, nPgmButtons[nPlayer][1]);
+			pgi->Macro.pVal[1] = bii.pVal;
+			pgi->Macro.nVal[1] = 1;
+			nMacroCount++;
+			pgi++;
+
+			pgi->nInput = GIT_MACRO_AUTO;
+			pgi->nType = BIT_DIGITAL;
+			pgi->Macro.nMode = 0;
+			sprintf(pgi->Macro.szName, "P%i Buttons CD", nPlayer + 1);
+			BurnDrvGetInputInfo(&bii, nPgmButtons[nPlayer][2]);
+			pgi->Macro.pVal[0] = bii.pVal;
+			pgi->Macro.nVal[0] = 1;
+			BurnDrvGetInputInfo(&bii, nPgmButtons[nPlayer][3]);
+			pgi->Macro.pVal[1] = bii.pVal;
+			pgi->Macro.nVal[1] = 1;
+			nMacroCount++;
+			pgi++;
+
+			pgi->nInput = GIT_MACRO_AUTO;
+			pgi->nType = BIT_DIGITAL;
+			pgi->Macro.nMode = 0;
+			sprintf(pgi->Macro.szName, "P%i Buttons ABC", nPlayer + 1);
+			BurnDrvGetInputInfo(&bii, nPgmButtons[nPlayer][0]);
+			pgi->Macro.pVal[0] = bii.pVal;
+			pgi->Macro.nVal[0] = 1;
+			BurnDrvGetInputInfo(&bii, nPgmButtons[nPlayer][1]);
+			pgi->Macro.pVal[1] = bii.pVal;
+			pgi->Macro.nVal[1] = 1;
+			BurnDrvGetInputInfo(&bii, nPgmButtons[nPlayer][2]);
 			pgi->Macro.pVal[2] = bii.pVal;
 			pgi->Macro.nVal[2] = 1;
+			nMacroCount++;
+			pgi++;
+
+			pgi->nInput = GIT_MACRO_AUTO;
+			pgi->nType = BIT_DIGITAL;
+			pgi->Macro.nMode = 0;
+			sprintf(pgi->Macro.szName, "P%i Buttons BC", nPlayer + 1);
+			BurnDrvGetInputInfo(&bii, nPgmButtons[nPlayer][1]);
+			pgi->Macro.pVal[0] = bii.pVal;
+			pgi->Macro.nVal[0] = 1;
+			BurnDrvGetInputInfo(&bii, nPgmButtons[nPlayer][2]);
+			pgi->Macro.pVal[1] = bii.pVal;
+			pgi->Macro.nVal[1] = 1;
+			nMacroCount++;
+			pgi++;
+		}
+		if (bIsCps1CartGame) {
+			pgi->nInput = GIT_MACRO_AUTO;
+			pgi->nType = BIT_DIGITAL;
+			pgi->Macro.nMode = 0;
+			sprintf(pgi->Macro.szName, "P%i Buttons AB", nPlayer + 1);
+			BurnDrvGetInputInfo(&bii, nCps1Buttons[nPlayer][0]);
+			pgi->Macro.pVal[0] = bii.pVal;
+			pgi->Macro.nVal[0] = 1;
+			BurnDrvGetInputInfo(&bii, nCps1Buttons[nPlayer][1]);
+			pgi->Macro.pVal[1] = bii.pVal;
+			pgi->Macro.nVal[1] = 1;
 			nMacroCount++;
 			pgi++;
 		}
@@ -1942,12 +2033,26 @@ static INT32 GameInpSpecialOne(struct GameInp* pgi, INT32 nPlayer, char* szb, ch
 	if (bIsNeogeoCartGame || (nGameType == RETRO_GAME_TYPE_NEOCD)) {
 		if (strncmp("Buttons ABC", description, 11) == 0)
 			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_4TH_COL_BOTTOM, description, RETRO_DEVICE_JOYPAD, GIT_MACRO_AUTO);
-		if (strncmp("Buttons BCD", description, 11) == 0)
+		if (strncmp("Buttons BC", description, 10) == 0)
 			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_4TH_COL_TOP, description, RETRO_DEVICE_JOYPAD, GIT_MACRO_AUTO);
 		if (strncmp("Buttons AB", description, 10) == 0)
 			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_3RD_COL_BOTTOM, description, RETRO_DEVICE_JOYPAD, GIT_MACRO_AUTO);
 		if (strncmp("Buttons CD", description, 10) == 0)
 			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_3RD_COL_TOP, description, RETRO_DEVICE_JOYPAD, GIT_MACRO_AUTO);
+	}
+	if (bIsPgmCartGame) {
+		if (strncmp("Buttons ABC", description, 11) == 0)
+			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_4TH_COL_BOTTOM, description, RETRO_DEVICE_JOYPAD, GIT_MACRO_AUTO);
+		if (strncmp("Buttons BC", description, 10) == 0)
+			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_4TH_COL_TOP, description, RETRO_DEVICE_JOYPAD, GIT_MACRO_AUTO);
+		if (strncmp("Buttons AB", description, 10) == 0)
+			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_3RD_COL_BOTTOM, description, RETRO_DEVICE_JOYPAD, GIT_MACRO_AUTO);
+		if (strncmp("Buttons CD", description, 10) == 0)
+			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_3RD_COL_TOP, description, RETRO_DEVICE_JOYPAD, GIT_MACRO_AUTO);
+	}
+	if (bIsCps1CartGame && !bStreetFighterLayout) {
+		if (strncmp("Buttons AB", description, 10) == 0)
+			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_4TH_COL_BOTTOM, description, RETRO_DEVICE_JOYPAD, GIT_MACRO_AUTO);
 	}
 
 	// Handle megadrive


### PR DESCRIPTION
Neogo combination button "BCD" has been changed to "BC".

The "BC" key combination is difficult to press on an Xbox controller. Especially when playing The King of Fighters 2002.

"BCD" combination button can be implemented by L1+L2, or L1+B, or L2+Y.

Add PGM combination button: R1-AB, R2-ABC, L1-CD, L2-BC.

Add CPS1 combination button: R2-AB.

The ABXY key of the controller is not suitable for pressing key combinations such as AB, CD, BC, ABC, BCD with the right thumb. With the assistance of the shoulder buttons, the gaming experience of the controller will be better. It's also a lot easier to play on Android with touchscreen buttons.